### PR TITLE
add optional spaces and removes after start token

### DIFF
--- a/syntax/helm.vim
+++ b/syntax/helm.vim
@@ -79,10 +79,10 @@ hi def link     gotplFunctions      Function
 hi def link     goSprigFunctions    Function
 hi def link     goTplVariable       Special
 
-syn region gotplAction start="{{" end="}}" contains=@gotplLiteral,gotplControl,gotplFunctions,goSprigFunctions,gotplVariable,goTplIdentifier containedin=yamlFlowString display
-syn region gotplAction start="\[\[" end="\]\]" contains=@gotplLiteral,gotplControl,gotplFunctions,goSprigFunctions,gotplVariable containedin=yamlFlowString display
-syn region goTplComment start="{{\(- \)\?/\*" end="\*/\( -\)\?}}" display
-syn region goTplComment start="\[\[\(- \)\?/\*" end="\*/\( -\)\?\]\]" display
+syn region gotplAction start="{{\(-? \)\?" end="\( -?\)\?}}" contains=@gotplLiteral,gotplControl,gotplFunctions,goSprigFunctions,gotplVariable,goTplIdentifier containedin=yamlFlowString display
+syn region gotplAction start="\[\[\(-? \)\?" end="\( -?\)\?\]\]" contains=@gotplLiteral,gotplControl,gotplFunctions,goSprigFunctions,gotplVariable containedin=yamlFlowString display
+syn region goTplComment start="{{\(-? \)\?/\*" end="\*/\( -?\)\?}}" display
+syn region goTplComment start="\[\[\(-? \)\?/\*" end="\*/\( -?\)\?\]\]" display
 
 hi def link gotplAction PreProc
 hi def link goTplComment Comment


### PR DESCRIPTION
Hi,

I was using the plugin but got a whole of red errors because I use spaces in the start and stop tokens `{{`. I'm not a vim expert and this is my first fix on a vim plugin 😃so maybe I'm wrong.

I use too different ways that got error from the plugin:
 - starting the token with `{{- statement_here` and ending with `statement_here -}}`
 - starting the token with `{{ statement_here` and ending with `statement_here }}`.
If in the two cases I remove the spaces there is no error by the plugin, but as far as I know gotpl I can use spaces.