### PR TITLE
escape ? to fix chomping modifier detection

### DIFF
--- a/syntax/helm.vim
+++ b/syntax/helm.vim
@@ -79,10 +79,10 @@ hi def link     gotplFunctions      Function
 hi def link     goSprigFunctions    Function
 hi def link     goTplVariable       Special
 
-syn region gotplAction start="{{\(-? \)\?" end="\( -?\)\?}}" contains=@gotplLiteral,gotplControl,gotplFunctions,goSprigFunctions,gotplVariable,goTplIdentifier containedin=yamlFlowString display
-syn region gotplAction start="\[\[\(-? \)\?" end="\( -?\)\?\]\]" contains=@gotplLiteral,gotplControl,gotplFunctions,goSprigFunctions,gotplVariable containedin=yamlFlowString display
-syn region goTplComment start="{{\(-? \)\?/\*" end="\*/\( -?\)\?}}" display
-syn region goTplComment start="\[\[\(-? \)\?/\*" end="\*/\( -?\)\?\]\]" display
+syn region gotplAction start="{{\(-\? \)\?" end="\( -\?\)\?}}" contains=@gotplLiteral,gotplControl,gotplFunctions,goSprigFunctions,gotplVariable,goTplIdentifier containedin=yamlFlowString display
+syn region gotplAction start="\[\[\(-\? \)\?" end="\( -\?\)\?\]\]" contains=@gotplLiteral,gotplControl,gotplFunctions,goSprigFunctions,gotplVariable containedin=yamlFlowString display
+syn region goTplComment start="{{\(-\? \)\?/\*" end="\*/\( -\?\)\?}}" display
+syn region goTplComment start="\[\[\(-\? \)\?/\*" end="\*/\( -\?\)\?\]\]" display
 
 hi def link gotplAction PreProc
 hi def link goTplComment Comment


### PR DESCRIPTION
I noticed that comments with chomping modifier were not marked as comments and traced it back to the regex not being properly escaped.
When using my fork as plugin, the helm comment `{{- /* test */}}` is shown properly, while previously it was not.