### PR TITLE
Add .yml pattern matching in ftdetect

### DIFF
--- a/ftdetect/helm.vim
+++ b/ftdetect/helm.vim
@@ -1,4 +1,4 @@
-autocmd BufRead,BufNewFile */templates/*.yaml,*/templates/*.tpl,*.gotmpl,helmfile*.yaml set ft=helm
+autocmd BufRead,BufNewFile */templates/*.{yaml,yml},*/templates/*.tpl,*.gotmpl,helmfile*.{yaml,yml} set ft=helm
 
 " Use {{/* */}} as comments
 autocmd FileType helm setlocal commentstring={{/*\ %s\ */}}


### PR DESCRIPTION
Relating to #7 

Support `.yml` instead of only `.yaml`. 