### PR TITLE
Fix ftdetect with other protocols (like oil://)

### DIFF
--- a/ftdetect/helm.vim
+++ b/ftdetect/helm.vim
@@ -3,7 +3,7 @@ function! s:isHelm()
   let filename = expand("%:t")
   if filepath =~ '\v/(templates|charts)/.*\.(ya?ml|gotmpl|tpl|txt)$' | return 1 | en
   if filename =~ '\v(helmfile).ya?ml' | return 1 | en
-  if !empty(findfile("Chart.yaml", expand('%:p:h').';')) | return 1 | en
+  if filepath !~ '\v^\w+://' && !empty(findfile("Chart.yaml", expand('%:p:h').';')) | return 1 | en
   return 0
 endfunction
 


### PR DESCRIPTION
findfile does not work for other protocols (uri that contains `://`). This fix simply disable `Chart.yaml` search if the current filepath starts with such uri.

For an example of why the current behavior is bad: Oil (netwr replacement) uses oil://path/of/directory for its file paths. Without this fix, oil's ft is always set to helm.

Fixes #24