### PR TITLE
feat: add yaml.helm-values filetype

### DIFF
--- a/ftdetect/helm.vim
+++ b/ftdetect/helm.vim
@@ -16,6 +16,7 @@ function! s:isHelm()
 endfunction
 
 autocmd BufRead,BufNewFile * if s:isHelm() | set ft=helm | endif
+autocmd BufRead,BufNewFile values*.yaml setfiletype yaml.helm-values
 
 " Use {{/* */}} as comments
 autocmd FileType helm setlocal commentstring={{/*\ %s\ */}}


### PR DESCRIPTION
this filetype is used by https://github.com/mrjosh/helm-ls/ to support completion of values.yaml files in the newest version. It would be cool if the ft could be included here since a lot of users are using this plugin with helm-ls.